### PR TITLE
Updates: 11.0 SDK, pjsip 2.7, openh264 1.7

### DIFF
--- a/openh264.sh
+++ b/openh264.sh
@@ -6,7 +6,7 @@ __FILE__=`realpath "$0"`
 __DIR__=`dirname "${__FILE__}"`
 
 BASEDIR_PATH="$1"
-TARGET_URL="https://github.com/cisco/openh264/archive/v1.6.0.zip"
+TARGET_URL="https://github.com/cisco/openh264/archive/v1.7.0.zip"
 TARGET_PATH="${BASEDIR_PATH}/src"
 
 # download

--- a/opus.sh
+++ b/opus.sh
@@ -23,7 +23,7 @@
 #  Choose your libopus version and your currently-installed iOS SDK version:
 #
 VERSION="1.1.3"
-SDKVERSION="10.3"
+SDKVERSION="11.0"
 MINIOSVERSION="8.0"
 
 ###########################################################################
@@ -127,7 +127,7 @@ do
     # Build the application and install it to the fake SDK intermediary dir
     # we have set up. Make sure to clean up afterward because we will re-use
     # this source tree to cross-compile other targets.
-	make -j4
+	make -j8
 	make install
 	make clean
 done

--- a/pjsip.sh
+++ b/pjsip.sh
@@ -11,7 +11,7 @@ function download() {
 }
 
 BASE_DIR="$1"
-PJSIP_URL="http://www.pjsip.org/release/2.6/pjproject-2.6.tar.bz2"
+PJSIP_URL="http://www.pjsip.org/release/2.7/pjproject-2.7.tar.bz2"
 PJSIP_DIR="$1/src"
 LIB_PATHS=("pjlib/lib" \
            "pjlib-util/lib" \
@@ -166,16 +166,19 @@ function _build() {
 }
 
 function armv7() {
+    export DEVPATH="`xcrun -sdk iphoneos --show-sdk-platform-path`/Developer"
     export CFLAGS="-miphoneos-version-min=8.0"
     export LDFLAGS=
     _build "armv7"
 }
 function armv7s() {
+    export DEVPATH="`xcrun -sdk iphoneos --show-sdk-platform-path`/Developer"
     export CFLAGS="-miphoneos-version-min=8.0"
     export LDFLAGS=
     _build "armv7s"
 }
 function arm64() {
+    export DEVPATH="`xcrun -sdk iphoneos --show-sdk-platform-path`/Developer"
     export CFLAGS="-miphoneos-version-min=8.0"
     export LDFLAGS=
     _build "arm64"


### PR DESCRIPTION
PJSIP's `DEVPATH` suggestion will fail on case-sensitive file systems